### PR TITLE
docs(skills): switch shorts install command to smithery

### DIFF
--- a/skills/citedy-video-shorts/README.md
+++ b/skills/citedy-video-shorts/README.md
@@ -40,7 +40,7 @@ Most video tools stop at "generate a clip".
 ### OpenSkills
 
 ```bash
-npx openskills install citedy/shorts
+npx @smithery/cli@latest skill add citedy/shorts
 ```
 
 ### Codex / local agent setup


### PR DESCRIPTION
Update the citedy-video-shorts skill README to use the new Smithery install command instead of the old openskills install command.