### PR TITLE
docs(skills): replace OpenSkills label with agent list

### DIFF
--- a/skills/citedy-video-shorts/README.md
+++ b/skills/citedy-video-shorts/README.md
@@ -37,7 +37,7 @@ Most video tools stop at "generate a clip".
 
 ## Install
 
-### OpenSkills
+### Claude Code, Codex, Droid, Antigravity, Cursor, OpenClaw, and more
 
 ```bash
 npx @smithery/cli@latest skill add citedy/shorts

--- a/skills/citedy-video-shorts/README.md
+++ b/skills/citedy-video-shorts/README.md
@@ -40,7 +40,7 @@ Most video tools stop at "generate a clip".
 ### OpenSkills
 
 ```bash
-npx openskills install citedy/shorts
+npx @smithery/cli@latest skill add citedy/shorts
 ```
 
 ### Codex / local agent setup


### PR DESCRIPTION
Replace the vague OpenSkills label with a concrete agent-facing install heading and keep the Smithery command directly below it.