### PR TITLE
feat(skills): add favorite_id scope to gaps endpoints

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "citedy-seo-agent",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "AI Marketing Agent — SEO, GEO, trend scouting, competitor analysis, content gaps, Google Search Console reports, article generation in 55 languages with AI illustrations and voice-over, article lifecycle management (publish/unpublish/delete), social adaptations (X, LinkedIn, Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, Shopify), lead magnets, content ingestion (YouTube, web, PDF, audio), short-form AI UGC viral videos with subtitles and direct video publishing to Instagram Reels and YouTube Shorts, turbo mode, webhooks, and automated content autopilot.",
   "author": {
     "name": "Citedy",

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.5.0"
+version: "3.6.0"
 author: Citedy
 tags:
   - seo
@@ -304,19 +304,25 @@ POST /api/agent/scout/reddit
 ### Get Content Gaps
 
 ```http
-GET /api/agent/gaps
+GET /api/agent/gaps?favorite_id=<uuid>&limit=<1-100>
 ```
 
 - 0 credits (free read)
+- `favorite_id` (uuid, optional) — scope results to a specific product/identity (`ai_favorites` row). Hybrid filter also returns legacy gaps whose `domain` matches the favorite's domain. Owner-checked → `403` for cross-tenant favorites.
+- `limit` (1-100, default 100, optional)
 
 ### Generate Content Gaps
 
 ```http
 POST /api/agent/gaps/generate
-{"competitor_urls": ["https://competitor1.com", "https://competitor2.com"]}
+{
+  "competitor_urls": ["https://competitor1.com", "https://competitor2.com"],
+  "favorite_id": "00000000-0000-0000-0000-000000000000"
+}
 ```
 
 - 40 credits. Synchronous — returns results directly.
+- `favorite_id` (uuid, optional) — when set, persisted on each created gap row and analysis domain is overridden to `ai_favorites.domain`. Owner-checked **before** charge → `403` for cross-tenant.
 
 ### Discover Competitors
 

--- a/autogpt/actions.json
+++ b/autogpt/actions.json
@@ -283,20 +283,21 @@
       "id": "gaps_get",
       "method": "GET",
       "path": "/api/agent/gaps",
-      "description": "Get existing content gaps",
+      "description": "Get existing content gaps. Optional ?favorite_id=<uuid> scopes to a product/identity (owner-checked, hybrid filter); ?limit=1-100 (default 100).",
       "cost": "free"
     },
     {
       "id": "gaps_generate",
       "method": "POST",
       "path": "/api/agent/gaps/generate",
-      "description": "Generate competitor content gaps",
+      "description": "Generate competitor content gaps. Optional favorite_id (uuid) scopes the run to a product/identity — owner-checked before charge (403 cross-tenant), persisted on each gap, overrides analysis domain to ai_favorites.domain.",
       "cost": "40 credits",
       "payload_example": {
         "competitor_urls": [
           "https://competitor1.com",
           "https://competitor2.com"
-        ]
+        ],
+        "favorite_id": "00000000-0000-0000-0000-000000000000"
       }
     },
     {

--- a/autogpt/agents/citedy-gap-to-publish.agent.json
+++ b/autogpt/agents/citedy-gap-to-publish.agent.json
@@ -47,7 +47,7 @@
       "input_default": {
         "name": "Request JSON",
         "title": null,
-        "value": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ]\n}",
+        "value": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ],\n  \"favorite_id\": \"\"\n}",
         "secret": false,
         "advanced": false,
         "description": "JSON payload for this endpoint.",
@@ -563,7 +563,7 @@
         "secret": false,
         "title": "Request JSON",
         "description": "JSON payload for the selected Citedy endpoint.",
-        "default": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ]\n}"
+        "default": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ],\n  \"favorite_id\": \"\"\n}"
       }
     },
     "required": ["API Key", "Request JSON"]

--- a/autogpt/agents/manifest.json
+++ b/autogpt/agents/manifest.json
@@ -53,7 +53,7 @@
       "id": "citedy-gap-generator",
       "file": "citedy-gap-to-publish.agent.json",
       "name": "Citedy Gap Generator",
-      "description": "Analyze competitors and surface content gaps where they earn traffic and you don't (~40 credits). Get a prioritized list of topics with genuine ranking potential.",
+      "description": "Analyze competitors and surface content gaps where they earn traffic and you don't (~40 credits). Get a prioritized list of topics with genuine ranking potential. Optional `favorite_id` (uuid) scopes the run to a specific product/identity (owner-checked).",
       "endpoint": "https://www.citedy.com/api/agent/gaps/generate",
       "method": "POST"
     },

--- a/integrations/langchain.md
+++ b/integrations/langchain.md
@@ -190,7 +190,7 @@ SYSTEM_PROMPT = """You are a content marketing strategist using the Citedy platf
 Your workflow for content pipeline tasks:
 1. Call agent.status to confirm sufficient credits before starting.
 2. Call competitors.scout with the provided domain (mode="fast").
-3. Call gaps.generate with competitor_urls set to that domain URL.
+3. Call gaps.generate with competitor_urls set to that domain URL. Pass `favorite_id` if the agent is scoped to a specific product/identity (optional, owner-checked).
 4. Pick the highest-impact gap topic from the results.
 5. Call article.generate with that topic, size="standard", enable_search=true.
 6. Return a concise summary including the published article URL.

--- a/integrations/n8n.md
+++ b/integrations/n8n.md
@@ -143,13 +143,16 @@ opportunities.
   "competitor_urls": [
     "https://competitor-one.com/blog",
     "https://competitor-two.com"
-  ]
+  ],
+  "favorite_id": "00000000-0000-0000-0000-000000000000"
 }
 ```
 
+`favorite_id` (optional uuid) scopes the run to a product/identity (owner-checked, 403 cross-tenant before charge). Persisted on each gap row; analysis domain switches to `ai_favorites.domain`.
+
 ### 4. gaps.list
 
-No parameters required. Returns saved gap opportunities with `score`, `priority`, `keyword`, and `rationale` fields.
+Optional query: `?favorite_id=<uuid>&limit=<1-100>`. With `favorite_id` set, returns gaps tagged with that favorite plus legacy NULL gaps whose `domain` matches the favorite's domain (hybrid filter). Default limit is 100. Response items include `score`, `priority`, `keyword`, `rationale`, and `favorite_id`.
 
 ### 5. Write to Google Sheets
 

--- a/integrations/openai-gpt-actions.md
+++ b/integrations/openai-gpt-actions.md
@@ -102,6 +102,11 @@ GPT Actions has a payload size limit. The full spec may hit this limit. Extract 
                   "competitor_urls": {
                     "type": "array",
                     "items": { "type": "string" }
+                  },
+                  "favorite_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "Optional product/identity scope (ai_favorites row). Owner-checked before charge → 403 cross-tenant. Persisted on each gap row; analysis domain overridden to ai_favorites.domain."
                   }
                 },
                 "required": ["competitor_urls"]
@@ -109,7 +114,35 @@ GPT Actions has a payload size limit. The full spec may hit this limit. Extract 
             }
           }
         },
-        "responses": { "200": { "description": "Gaps generated" } }
+        "responses": {
+          "200": { "description": "Gaps generated" },
+          "403": { "description": "favorite_id not owned by tenant" }
+        }
+      }
+    },
+    "/api/agent/gaps": {
+      "get": {
+        "operationId": "listContentGaps",
+        "summary": "Read saved content gaps",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "favorite_id",
+            "required": false,
+            "schema": { "type": "string", "format": "uuid" },
+            "description": "Filter to gaps tagged with this favorite. Hybrid filter also returns legacy NULL gaps whose domain matches favorite.domain (when normalizeDomain succeeds)."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 100 }
+          }
+        ],
+        "responses": {
+          "200": { "description": "List of gaps" },
+          "403": { "description": "favorite_id not owned by tenant" }
+        }
       }
     },
     "/api/agent/competitors/scout": {

--- a/integrations/zapier.md
+++ b/integrations/zapier.md
@@ -118,9 +118,12 @@ Every Friday at 09:00 AM.
   "competitor_urls": [
     "https://www.competitor-one.com",
     "https://www.competitor-two.com"
-  ]
+  ],
+  "favorite_id": "00000000-0000-0000-0000-000000000000"
 }
 ```
+
+`favorite_id` (optional uuid) scopes the run to a product/identity in `ai_favorites`. Owner-checked before charge (403 cross-tenant). Each created gap row is tagged with the favorite, and analysis domain is overridden to the favorite's domain.
 
 ### Step 3 — Action: Retrieve gap results
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -304,19 +304,25 @@ POST /api/agent/scout/reddit
 ### Get Content Gaps
 
 ```http
-GET /api/agent/gaps
+GET /api/agent/gaps?favorite_id=<uuid>&limit=<1-100>
 ```
 
 - 0 credits (free read)
+- `favorite_id` (uuid, optional) — scope results to a specific product/identity (`ai_favorites` row). Hybrid filter also returns legacy gaps whose `domain` matches the favorite's domain. Owner-checked → `403` for cross-tenant favorites.
+- `limit` (1-100, default 100, optional)
 
 ### Generate Content Gaps
 
 ```http
 POST /api/agent/gaps/generate
-{"competitor_urls": ["https://competitor1.com", "https://competitor2.com"]}
+{
+  "competitor_urls": ["https://competitor1.com", "https://competitor2.com"],
+  "favorite_id": "00000000-0000-0000-0000-000000000000"
+}
 ```
 
 - 40 credits. Synchronous — returns results directly.
+- `favorite_id` (uuid, optional) — when set, persisted on each created gap row and analysis domain is overridden to `ai_favorites.domain`. Owner-checked **before** charge → `403` for cross-tenant.
 
 ### Discover Competitors
 

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -304,19 +304,25 @@ POST /api/agent/scout/reddit
 ### Get Content Gaps
 
 ```http
-GET /api/agent/gaps
+GET /api/agent/gaps?favorite_id=<uuid>&limit=<1-100>
 ```
 
 - 0 credits (free read)
+- `favorite_id` (uuid, optional) — scope results to a specific product/identity (`ai_favorites` row). Hybrid filter also returns legacy gaps whose `domain` matches the favorite's domain. Owner-checked → `403` for cross-tenant favorites.
+- `limit` (1-100, default 100, optional)
 
 ### Generate Content Gaps
 
 ```http
 POST /api/agent/gaps/generate
-{"competitor_urls": ["https://competitor1.com", "https://competitor2.com"]}
+{
+  "competitor_urls": ["https://competitor1.com", "https://competitor2.com"],
+  "favorite_id": "00000000-0000-0000-0000-000000000000"
+}
 ```
 
 - 40 credits. Synchronous — returns results directly.
+- `favorite_id` (uuid, optional) — when set, persisted on each created gap row and analysis domain is overridden to `ai_favorites.domain`. Owner-checked **before** charge → `403` for cross-tenant.
 
 ### Discover Competitors
 


### PR DESCRIPTION
## Summary

Sync with saas-blog PR [#596](https://github.com/nttylock/saas-blog/pull/596): optional `favorite_id` (uuid) on `POST /api/agent/gaps/generate` and `GET /api/agent/gaps`.

## Behaviour

- Owner-checked against `ai_favorites` → **403** for cross-tenant favorites BEFORE charge (no credit burn on probing).
- When set on `gaps.generate`: persisted on each created gap row; analysis domain overridden to `ai_favorites.domain` instead of `${blog_handle}.citedy.com`.
- `gaps.list?favorite_id=X` uses a hybrid filter: rows tagged with the favorite **plus** legacy NULL rows whose `domain` matches (with bare/www variants).
- `gaps.list` also accepts `?limit=1-100` (default 100).

## Files updated (11)

- `.claude-plugin/plugin.json` — version bump 3.5.0 → 3.6.0
- `SKILL.md` (+ `openclaw/SKILL.md`, `skills/citedy-seo-agent/SKILL.md` copies)
- `integrations/openai-gpt-actions.md` — embedded OpenAPI schema for ChatGPT custom GPT (added `favorite_id` to `generateContentGaps`, new `listContentGaps` operation with query params, new 403 response)
- `integrations/{langchain,n8n,zapier}.md` — example bodies + prose
- `autogpt/actions.json` — `gaps_get` description + `gaps_generate` description + `payload_example`
- `autogpt/agents/citedy-gap-to-publish.agent.json` — request JSON template default
- `autogpt/agents/manifest.json` — Citedy Gap Generator description

## Backwards compatibility

All changes additive optional. Legacy callers continue to work without `favorite_id` / `limit`.

## Verified upstream

PR #596 verified end-to-end with real Supabase + real Gemini API:
- `gaps.list`: hybrid filter returns exactly bare-host matches (10/150 in test tenant)
- `gaps.generate`: 403 on cross-tenant favorite without charge; 200 with owned favorite, 5 gaps inserted with `favorite_id`, 40 cr deducted, activity log captures payload + transaction id