### PR TITLE
chore(skills): bump 3.6.1 + bot-flagged docs cleanup + grounded pricing/feature fixes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "citedy-seo-agent",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "AI Marketing Agent — SEO, GEO, trend scouting, competitor analysis, content gaps, Google Search Console reports, article generation in 55 languages with AI illustrations and voice-over, article lifecycle management (publish/unpublish/delete), social adaptations (X, LinkedIn, Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, Shopify), lead magnets, content ingestion (YouTube, web, PDF, audio), short-form AI UGC viral videos with subtitles and direct video publishing to Instagram Reels and YouTube Shorts, turbo mode, webhooks, and automated content autopilot.",
   "author": {
     "name": "Citedy",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Citedy SEO Agent is designed for developers, marketers, and AI enthusiasts w
 | **AI-Powered Enhancements** | Add AI-generated illustrations and voice-over narration to your articles.                                                                     |
 | **Social Media Adaptation** | Adapt articles for X, LinkedIn, Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, and Shopify.                           |
 | **Direct Publish**          | Publish article content as-is to LinkedIn, Facebook, X, Reddit, and Instagram — no AI adaptation, 0 credits.                                  |
-| **AI UGC Viral Videos**     | Generate short-form AI UGC viral videos (5s/10s/15s) with subtitles. Direct publish to Instagram Reels (5 credits) and YouTube Shorts (free). |
+| **AI UGC Viral Videos**     | Generate short-form AI UGC viral videos (5s/10s/15s) with subtitles. Direct publish to Instagram Reels, YouTube Shorts, and TikTok — publishing is free across all platforms.                |
 | **Content Ingestion**       | Extract content from YouTube videos, web articles, PDFs, and audio files into structured summaries.                                           |
 | **Lead Magnets**            | Generate checklists, swipe files, and frameworks for lead capture — from 30 credits.                                                          |
 | **GSC Reports**             | Google Search Console performance reports — clicks, impressions, positions, movers, opportunities, article suggestions. 0 credits.            |

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.6.0"
+version: "3.6.1"
 author: Citedy
 tags:
   - seo
@@ -914,7 +914,7 @@ POST /api/agent/publish
 
 - 0 credits (5 for `instagram_reels`)
 - `action` — `now` (publish immediately) | `schedule` (requires `scheduledAt`) | `cancel` (cancel scheduled)
-- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram`
+- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels`
 - `accountId` — social account UUID (from `/me` connected_platforms)
 - `scheduledAt` — ISO datetime, required for `action=schedule`
 
@@ -1380,5 +1380,5 @@ Call `GET /api/agent/me` every 4 hours as a keep-alive. This updates `last_activ
 
 ---
 
-_Citedy SEO Agent Skill v3.1.0_
+_Citedy SEO Agent Skill v3.6.1_
 _https://www.citedy.com_

--- a/SKILL.md
+++ b/SKILL.md
@@ -735,7 +735,7 @@ Generate AI UGC viral videos with subtitles — from script to finished video.
 2. `/shorts/avatar` — generate AI avatar image (user approves)
 3. `/shorts` — generate video segment(s) with avatar + prompt + speech_text
 4. `/shorts/merge` — merge segments + add professional subtitles (if multi-segment)
-5. `/shorts/publish` — publish video directly to YouTube Shorts and/or Instagram Reels
+5. `/shorts/publish` — publish video directly to YouTube Shorts, Instagram Reels, and/or TikTok
 
 **Generate Script:**
 
@@ -832,17 +832,20 @@ POST /api/agent/shorts/publish
   "speech_text": "I just found 8 hidden competitors in 3 minutes...",
   "targets": [
     {"platform": "instagram_reels", "account_id": "uuid-of-ig-account"},
-    {"platform": "youtube_shorts", "account_id": "uuid-of-yt-account"}
+    {"platform": "youtube_shorts", "account_id": "uuid-of-yt-account"},
+    {"platform": "tiktok", "account_id": "uuid-of-tt-account"}
   ],
-  "privacy_status": "public"
+  "privacy_status": "public",
+  "tiktok_privacy_level": "PUBLIC_TO_EVERYONE"
 }
 ```
 
-- Instagram Reels: 5 credits. YouTube Shorts: 0 credits (free)
+- Publishing is free across all platforms (Instagram Reels: 0 credits, YouTube Shorts: 0 credits, TikTok: 0 credits) since 2026-04-15. See `lib/billing/pricing-constants.ts` `SOCIAL_PUBLISH_CREDITS` — revenue moved to generation only.
 - `video_url` — HTTPS URL from `/shorts` or `/shorts/merge` response (must be `download.citedy.com` or Supabase storage)
 - `speech_text` — original spoken text; used to derive title, hashtags, descriptions via LLM
-- `targets` — 1-2 entries, each platform may appear at most once. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
-- `privacy_status` — `public` (default), `unlisted`, `private` (YouTube only, ignored for Instagram)
+- `targets` — 1-3 entries (max 3 platforms), each platform may appear at most once. `platform` is one of `youtube_shorts` | `instagram_reels` | `tiktok`. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
+- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. TikTok ignores it whenever `tiktok_privacy_level` is provided (always set `tiktok_privacy_level` explicitly when publishing to TikTok)
+- `tiktok_privacy_level` — TikTok-only and **required** when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
 - Returns `{ results: [{ platform, ok, post_id?, error? }], metadata_provider, metadata_degraded, timings: { metadata_ms, total_ms }, credits_charged }`
 - Does **not** require an article — publishes directly from video URL + speech text
 
@@ -856,10 +859,11 @@ POST /api/agent/shorts/publish
 | Video (10s)                 | 130     |
 | Video (15s)                 | 185     |
 | Merge + subtitles           | 5       |
-| Publish (IG Reels)          | 5       |
+| Publish (IG Reels)          | 0       |
 | Publish (YT Shorts)         | 0       |
+| Publish (TikTok)            | 0       |
 | **Full 10s video**          | **139** |
-| **Full 10s + publish both** | **144** |
+| **Full 10s + publish all**  | **139** |
 
 ### Trend Scan
 
@@ -912,9 +916,9 @@ POST /api/agent/publish
 }
 ```
 
-- 0 credits (5 for `instagram_reels`)
+- 0 credits (publishing is free across all platforms since 2026-04-15)
 - `action` — `now` (publish immediately) | `schedule` (requires `scheduledAt`) | `cancel` (cancel scheduled)
-- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels`
+- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels` | `youtube_shorts`
 - `accountId` — social account UUID (from `/me` connected_platforms)
 - `scheduledAt` — ISO datetime, required for `action=schedule`
 
@@ -1157,7 +1161,7 @@ Use `connected_platforms` to decide which platforms to pass to `/api/agent/adapt
 | `/api/agent/post`                  | POST   | 2 credits                            |
 | `/api/agent/autopilot`             | POST   | 2-139 credits                        |
 | `/api/agent/adapt`                 | POST   | ~5 credits/platform                  |
-| `/api/agent/publish`               | POST   | 0 credits (5 for `instagram_reels`)  |
+| `/api/agent/publish`               | POST   | 0 credits (publishing is free)       |
 | `/api/agent/session`               | POST   | free (articles billed on generation) |
 | `/api/agent/schedule`              | GET    | free                                 |
 | `/api/agent/schedule/gaps`         | GET    | free                                 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1191,7 +1191,7 @@ Use `connected_platforms` to decide which platforms to pass to `/api/agent/adapt
 | `/api/agent/shorts`                | POST   | 60-185 credits (by duration)         |
 | `/api/agent/shorts/{id}`           | GET    | free (poll)                          |
 | `/api/agent/shorts/merge`          | POST   | 5 credits                            |
-| `/api/agent/shorts/publish`        | POST   | 0-5 credits (YT free, IG 5)          |
+| `/api/agent/shorts/publish`        | POST   | 0 credits (publishing is free)       |
 | `/api/agent/webhooks`              | POST   | free                                 |
 | `/api/agent/webhooks`              | GET    | free                                 |
 | `/api/agent/webhooks/{id}`         | DELETE | free                                 |

--- a/autogpt/actions.json
+++ b/autogpt/actions.json
@@ -523,13 +523,18 @@
       "id": "shorts_publish",
       "method": "POST",
       "path": "/api/agent/shorts/publish",
-      "description": "Publish video directly to YouTube Shorts and/or Instagram Reels",
-      "cost": "0-5 credits (YT free, IG 5)",
+      "description": "Publish video directly to YouTube Shorts, Instagram Reels, and/or TikTok. tiktok_privacy_level is required when targets includes TikTok.",
+      "cost": "free",
       "payload_example": {
         "video_url": "https://download.citedy.com/agent/shorts/.../video-sub.mp4",
         "speech_text": "I just found 8 hidden competitors in 3 minutes...",
-        "targets": [{ "platform": "instagram_reels", "account_id": "uuid" }],
-        "privacy_status": "public"
+        "targets": [
+          { "platform": "instagram_reels", "account_id": "uuid-of-ig" },
+          { "platform": "youtube_shorts", "account_id": "uuid-of-yt" },
+          { "platform": "tiktok", "account_id": "uuid-of-tt" }
+        ],
+        "privacy_status": "public",
+        "tiktok_privacy_level": "PUBLIC_TO_EVERYONE"
       }
     },
     {

--- a/autogpt/agents/citedy-gap-to-publish.agent.json
+++ b/autogpt/agents/citedy-gap-to-publish.agent.json
@@ -47,7 +47,7 @@
       "input_default": {
         "name": "Request JSON",
         "title": null,
-        "value": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ],\n  \"favorite_id\": \"\"\n}",
+        "value": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ]\n}",
         "secret": false,
         "advanced": false,
         "description": "JSON payload for this endpoint.",
@@ -563,7 +563,7 @@
         "secret": false,
         "title": "Request JSON",
         "description": "JSON payload for the selected Citedy endpoint.",
-        "default": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ],\n  \"favorite_id\": \"\"\n}"
+        "default": "{\n  \"competitor_urls\": [\n    \"https://example1.com\",\n    \"https://example2.com\"\n  ]\n}"
       }
     },
     "required": ["API Key", "Request JSON"]

--- a/integrations/openai-gpt-actions.md
+++ b/integrations/openai-gpt-actions.md
@@ -51,7 +51,7 @@ In the Actions editor, under **Authentication**:
 
 GPT Actions has a payload size limit. The full spec may hit this limit. Extract only the operations your GPT needs.
 
-**Minimal SEO assistant spec** (5 key operations):
+**Minimal SEO assistant spec** (6 key operations):
 
 ```json
 {
@@ -410,7 +410,7 @@ Once connected, ChatGPT can invoke Citedy tools directly in conversation without
 
 ## Trimming the OpenAPI Spec for GPT Actions
 
-GPT Actions enforces limits on spec size. If you need more than the 5 operations in the minimal spec above, follow this approach.
+GPT Actions enforces limits on spec size. If you need more than the 6 operations in the minimal spec above, follow this approach.
 
 ### Operations Reference
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -735,7 +735,7 @@ Generate AI UGC viral videos with subtitles — from script to finished video.
 2. `/shorts/avatar` — generate AI avatar image (user approves)
 3. `/shorts` — generate video segment(s) with avatar + prompt + speech_text
 4. `/shorts/merge` — merge segments + add professional subtitles (if multi-segment)
-5. `/shorts/publish` — publish video directly to YouTube Shorts and/or Instagram Reels
+5. `/shorts/publish` — publish video directly to YouTube Shorts, Instagram Reels, and/or TikTok
 
 **Generate Script:**
 
@@ -832,17 +832,20 @@ POST /api/agent/shorts/publish
   "speech_text": "I just found 8 hidden competitors in 3 minutes...",
   "targets": [
     {"platform": "instagram_reels", "account_id": "uuid-of-ig-account"},
-    {"platform": "youtube_shorts", "account_id": "uuid-of-yt-account"}
+    {"platform": "youtube_shorts", "account_id": "uuid-of-yt-account"},
+    {"platform": "tiktok", "account_id": "uuid-of-tt-account"}
   ],
-  "privacy_status": "public"
+  "privacy_status": "public",
+  "tiktok_privacy_level": "PUBLIC_TO_EVERYONE"
 }
 ```
 
-- Instagram Reels: 5 credits. YouTube Shorts: 0 credits (free)
+- Publishing is free across all platforms (Instagram Reels: 0 credits, YouTube Shorts: 0 credits, TikTok: 0 credits) since 2026-04-15. See `lib/billing/pricing-constants.ts` `SOCIAL_PUBLISH_CREDITS` — revenue moved to generation only.
 - `video_url` — HTTPS URL from `/shorts` or `/shorts/merge` response (must be `download.citedy.com` or Supabase storage)
 - `speech_text` — original spoken text; used to derive title, hashtags, descriptions via LLM
-- `targets` — 1-2 entries, each platform may appear at most once. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
-- `privacy_status` — `public` (default), `unlisted`, `private` (YouTube only, ignored for Instagram)
+- `targets` — 1-3 entries (max 3 platforms), each platform may appear at most once. `platform` is one of `youtube_shorts` | `instagram_reels` | `tiktok`. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
+- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. TikTok ignores it whenever `tiktok_privacy_level` is provided (always set `tiktok_privacy_level` explicitly when publishing to TikTok)
+- `tiktok_privacy_level` — TikTok-only and **required** when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
 - Returns `{ results: [{ platform, ok, post_id?, error? }], metadata_provider, metadata_degraded, timings: { metadata_ms, total_ms }, credits_charged }`
 - Does **not** require an article — publishes directly from video URL + speech text
 
@@ -856,10 +859,11 @@ POST /api/agent/shorts/publish
 | Video (10s)                 | 130     |
 | Video (15s)                 | 185     |
 | Merge + subtitles           | 5       |
-| Publish (IG Reels)          | 5       |
+| Publish (IG Reels)          | 0       |
 | Publish (YT Shorts)         | 0       |
+| Publish (TikTok)            | 0       |
 | **Full 10s video**          | **139** |
-| **Full 10s + publish both** | **144** |
+| **Full 10s + publish all**  | **139** |
 
 ### Trend Scan
 
@@ -912,9 +916,9 @@ POST /api/agent/publish
 }
 ```
 
-- 0 credits (5 for `instagram_reels`)
+- 0 credits (publishing is free across all platforms since 2026-04-15)
 - `action` — `now` (publish immediately) | `schedule` (requires `scheduledAt`) | `cancel` (cancel scheduled)
-- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels`
+- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels` | `youtube_shorts`
 - `accountId` — social account UUID (from `/me` connected_platforms)
 - `scheduledAt` — ISO datetime, required for `action=schedule`
 
@@ -1157,7 +1161,7 @@ Use `connected_platforms` to decide which platforms to pass to `/api/agent/adapt
 | `/api/agent/post`                  | POST   | 2 credits                            |
 | `/api/agent/autopilot`             | POST   | 2-139 credits                        |
 | `/api/agent/adapt`                 | POST   | ~5 credits/platform                  |
-| `/api/agent/publish`               | POST   | 0 credits (5 for `instagram_reels`)  |
+| `/api/agent/publish`               | POST   | 0 credits (publishing is free)       |
 | `/api/agent/session`               | POST   | free (articles billed on generation) |
 | `/api/agent/schedule`              | GET    | free                                 |
 | `/api/agent/schedule/gaps`         | GET    | free                                 |

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.5.0"
+version: "3.6.1"
 author: Citedy
 tags:
   - seo
@@ -914,7 +914,7 @@ POST /api/agent/publish
 
 - 0 credits (5 for `instagram_reels`)
 - `action` — `now` (publish immediately) | `schedule` (requires `scheduledAt`) | `cancel` (cancel scheduled)
-- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram`
+- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels`
 - `accountId` — social account UUID (from `/me` connected_platforms)
 - `scheduledAt` — ISO datetime, required for `action=schedule`
 
@@ -1380,5 +1380,5 @@ Call `GET /api/agent/me` every 4 hours as a keep-alive. This updates `last_activ
 
 ---
 
-_Citedy SEO Agent Skill v3.1.0_
+_Citedy SEO Agent Skill v3.6.1_
 _https://www.citedy.com_

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -1191,7 +1191,7 @@ Use `connected_platforms` to decide which platforms to pass to `/api/agent/adapt
 | `/api/agent/shorts`                | POST   | 60-185 credits (by duration)         |
 | `/api/agent/shorts/{id}`           | GET    | free (poll)                          |
 | `/api/agent/shorts/merge`          | POST   | 5 credits                            |
-| `/api/agent/shorts/publish`        | POST   | 0-5 credits (YT free, IG 5)          |
+| `/api/agent/shorts/publish`        | POST   | 0 credits (publishing is free)       |
 | `/api/agent/webhooks`              | POST   | free                                 |
 | `/api/agent/webhooks`              | GET    | free                                 |
 | `/api/agent/webhooks/{id}`         | DELETE | free                                 |

--- a/skills/citedy-content-writer/SKILL.md
+++ b/skills/citedy-content-writer/SKILL.md
@@ -340,10 +340,9 @@ Content-Type: application/json
 
 **Agent flow:**
 
-1. Call `POST /api/agent/autopilot` with `source_urls: ["https://competitor.com/best-crm-tools"]`, `size: "standard"`, `language: "en"`
-2. Poll status or wait for webhook `article.completed`
-3. Return article title, URL, and word count to user
-4. Ask: "Want social media adaptations? Which platforms?"
+1. Call `POST /api/agent/autopilot` with `source_urls: ["https://competitor.com/best-crm-tools"]`, `size: "standard"`, `language: "en"` — synchronous; the response includes the full article (title, URL, word count, content)
+2. Return article title, URL, and word count to user
+3. Ask: "Want social media adaptations? Which platforms?"
 
 ---
 

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -735,7 +735,7 @@ Generate AI UGC viral videos with subtitles — from script to finished video.
 2. `/shorts/avatar` — generate AI avatar image (user approves)
 3. `/shorts` — generate video segment(s) with avatar + prompt + speech_text
 4. `/shorts/merge` — merge segments + add professional subtitles (if multi-segment)
-5. `/shorts/publish` — publish video directly to YouTube Shorts and/or Instagram Reels
+5. `/shorts/publish` — publish video directly to YouTube Shorts, Instagram Reels, and/or TikTok
 
 **Generate Script:**
 
@@ -832,17 +832,20 @@ POST /api/agent/shorts/publish
   "speech_text": "I just found 8 hidden competitors in 3 minutes...",
   "targets": [
     {"platform": "instagram_reels", "account_id": "uuid-of-ig-account"},
-    {"platform": "youtube_shorts", "account_id": "uuid-of-yt-account"}
+    {"platform": "youtube_shorts", "account_id": "uuid-of-yt-account"},
+    {"platform": "tiktok", "account_id": "uuid-of-tt-account"}
   ],
-  "privacy_status": "public"
+  "privacy_status": "public",
+  "tiktok_privacy_level": "PUBLIC_TO_EVERYONE"
 }
 ```
 
-- Instagram Reels: 5 credits. YouTube Shorts: 0 credits (free)
+- Publishing is free across all platforms (Instagram Reels: 0 credits, YouTube Shorts: 0 credits, TikTok: 0 credits) since 2026-04-15. See `lib/billing/pricing-constants.ts` `SOCIAL_PUBLISH_CREDITS` — revenue moved to generation only.
 - `video_url` — HTTPS URL from `/shorts` or `/shorts/merge` response (must be `download.citedy.com` or Supabase storage)
 - `speech_text` — original spoken text; used to derive title, hashtags, descriptions via LLM
-- `targets` — 1-2 entries, each platform may appear at most once. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
-- `privacy_status` — `public` (default), `unlisted`, `private` (YouTube only, ignored for Instagram)
+- `targets` — 1-3 entries (max 3 platforms), each platform may appear at most once. `platform` is one of `youtube_shorts` | `instagram_reels` | `tiktok`. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
+- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. TikTok ignores it whenever `tiktok_privacy_level` is provided (always set `tiktok_privacy_level` explicitly when publishing to TikTok)
+- `tiktok_privacy_level` — TikTok-only and **required** when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
 - Returns `{ results: [{ platform, ok, post_id?, error? }], metadata_provider, metadata_degraded, timings: { metadata_ms, total_ms }, credits_charged }`
 - Does **not** require an article — publishes directly from video URL + speech text
 
@@ -856,10 +859,11 @@ POST /api/agent/shorts/publish
 | Video (10s)                 | 130     |
 | Video (15s)                 | 185     |
 | Merge + subtitles           | 5       |
-| Publish (IG Reels)          | 5       |
+| Publish (IG Reels)          | 0       |
 | Publish (YT Shorts)         | 0       |
+| Publish (TikTok)            | 0       |
 | **Full 10s video**          | **139** |
-| **Full 10s + publish both** | **144** |
+| **Full 10s + publish all**  | **139** |
 
 ### Trend Scan
 
@@ -912,9 +916,9 @@ POST /api/agent/publish
 }
 ```
 
-- 0 credits (5 for `instagram_reels`)
+- 0 credits (publishing is free across all platforms since 2026-04-15)
 - `action` — `now` (publish immediately) | `schedule` (requires `scheduledAt`) | `cancel` (cancel scheduled)
-- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels`
+- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels` | `youtube_shorts`
 - `accountId` — social account UUID (from `/me` connected_platforms)
 - `scheduledAt` — ISO datetime, required for `action=schedule`
 
@@ -1157,7 +1161,7 @@ Use `connected_platforms` to decide which platforms to pass to `/api/agent/adapt
 | `/api/agent/post`                  | POST   | 2 credits                            |
 | `/api/agent/autopilot`             | POST   | 2-139 credits                        |
 | `/api/agent/adapt`                 | POST   | ~5 credits/platform                  |
-| `/api/agent/publish`               | POST   | 0 credits (5 for `instagram_reels`)  |
+| `/api/agent/publish`               | POST   | 0 credits (publishing is free)       |
 | `/api/agent/session`               | POST   | free (articles billed on generation) |
 | `/api/agent/schedule`              | GET    | free                                 |
 | `/api/agent/schedule/gaps`         | GET    | free                                 |

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.5.0"
+version: "3.6.1"
 author: Citedy
 tags:
   - seo
@@ -914,7 +914,7 @@ POST /api/agent/publish
 
 - 0 credits (5 for `instagram_reels`)
 - `action` — `now` (publish immediately) | `schedule` (requires `scheduledAt`) | `cancel` (cancel scheduled)
-- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram`
+- `platform` — `facebook` | `linkedin` | `x_article` | `x_thread` | `reddit` | `threads` | `instagram` | `instagram_reels`
 - `accountId` — social account UUID (from `/me` connected_platforms)
 - `scheduledAt` — ISO datetime, required for `action=schedule`
 
@@ -1380,5 +1380,5 @@ Call `GET /api/agent/me` every 4 hours as a keep-alive. This updates `last_activ
 
 ---
 
-_Citedy SEO Agent Skill v3.1.0_
+_Citedy SEO Agent Skill v3.6.1_
 _https://www.citedy.com_

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -1191,7 +1191,7 @@ Use `connected_platforms` to decide which platforms to pass to `/api/agent/adapt
 | `/api/agent/shorts`                | POST   | 60-185 credits (by duration)         |
 | `/api/agent/shorts/{id}`           | GET    | free (poll)                          |
 | `/api/agent/shorts/merge`          | POST   | 5 credits                            |
-| `/api/agent/shorts/publish`        | POST   | 0-5 credits (YT free, IG 5)          |
+| `/api/agent/shorts/publish`        | POST   | 0 credits (publishing is free)       |
 | `/api/agent/webhooks`              | POST   | free                                 |
 | `/api/agent/webhooks`              | GET    | free                                 |
 | `/api/agent/webhooks/{id}`         | DELETE | free                                 |


### PR DESCRIPTION
## Summary

Address 9 bot findings from saas-blog#598 (re-mirror PR), all of which were upstream issues here. Plus pricing/feature corrections grounded against the actual saas-blog code.

## Findings fixed

### Bot findings from saas-blog#598

- **Footer version drift (CR)** — `SKILL.md`, `openclaw/SKILL.md`, and `skills/citedy-seo-agent/SKILL.md` all had `_v3.1.0_` footer while frontmatter was 3.6.0 (or 3.5.0 in the 2 copies). Aligned all to `_v3.6.1_`.
- **Frontmatter parity (CR)** — `openclaw/SKILL.md` and `skills/citedy-seo-agent/SKILL.md` were stuck at 3.5.0 even after [#7](https://github.com/Citedy/citedy-seo-agent/pull/7). Bumped to 3.6.1.
- **Platform allowlist (CR ×3)** — `instagram_reels` was priced (5cr) but missing from the publish action's `platform` enum line. Added to all 3 SKILL.md copies. Then realised `youtube_shorts` was also missing — added that too.
- **"5 key operations" → "6 key operations" (CR)** — the minimal GPT spec in `integrations/openai-gpt-actions.md` gained `listContentGaps` in #7; outdated count at L54 + L413.
- **Sync/async contradiction (CR MAJOR + Codex P1 ×2)** — `skills/citedy-content-writer/SKILL.md` L344 told integrators to poll/wait for `article.completed` webhook (event name doesn't exist), L801 said synchronous. Aligned L344 to the synchronous reality.
- **autogpt template (CR)** — `citedy-gap-to-publish.agent.json` templates shipped with `"favorite_id": ""` — empty string fails uuid validation, so the out-of-box template would 4xx. Reverted to no `favorite_id` key; users add it from SKILL.md docs when needed.

### Corrections grounded against saas-blog code

- **Publishing is FREE across all platforms since 2026-04-15** — `lib/billing/pricing-constants.ts:729-735` `SOCIAL_PUBLISH_CREDITS = {youtube_shorts:0, instagram_reels:0, tiktok:0}`. Removed all "5 credits for instagram_reels" mentions across SKILL.md (3 copies), README.md, and pricing tables. The "Full 10s + publish both = 144" footer corrected to 139 (publish adds nothing).
- **TikTok added to `/api/agent/shorts/publish` examples** — `ShortsPublishTarget.platform` enum (`openapi/agent-api.openapi.json:7476-7478`) is `[youtube_shorts, instagram_reels, tiktok]`. Added TikTok to the targets example, bumped max targets to 1-3, documented `tiktok_privacy_level` field as **required when targets includes TikTok**. Modern UI sets it explicitly via `PublishDestinationPopover`; the legacy `privacy_status=private → SELF_ONLY` fallback in code is no longer recommended for new integrations.
- **`youtube_shorts` added to `/api/agent/publish` platform enum** — `PUBLISH_PLATFORMS` (`lib/social/publish-platforms.ts:6-16`) is `[facebook, linkedin, x_article, x_thread, reddit, threads, instagram, instagram_reels, youtube_shorts]`. The platform line was missing it.

## Version bump

`3.6.0 → 3.6.1` in 4 places: `.claude-plugin/plugin.json` + 3 `SKILL.md` frontmatters.

## Notes

- The UGC generator picker (`lib/social/short-video-platforms.ts:37-40` `CONNECTABLE_SHORT_VIDEO_ACCOUNT_PLATFORMS`) lists only `instagram + tiktok` for the inline account chooser. This is a UI convenience, not a runtime disable. `/shorts/publish` API and `Settings → Integrations` connect flow accept YouTube Shorts.
- After merge: bump clawhub registry to `citedy-seo-agent@3.6.1` via `clawhub publish`, then re-mirror to saas-blog as a single replacement PR for the closed #598.

## Test plan

- [x] No code changes — pure docs + JSON template fixes
- [x] Pre-commit checks (this repo doesn't have prettier hooks; verified file readability manually)
- [x] Bot review (CodeRabbit / Codex / Seer) — pending after push
