### PR TITLE
chore(skills): bump 3.6.2 — Codex P1 (async polling) + P2 (publishing status)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "citedy-seo-agent",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "AI Marketing Agent — SEO, GEO, trend scouting, competitor analysis, content gaps, Google Search Console reports, article generation in 55 languages with AI illustrations and voice-over, article lifecycle management (publish/unpublish/delete), social adaptations (X, LinkedIn, Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, Shopify), lead magnets, content ingestion (YouTube, web, PDF, audio), short-form AI UGC viral videos with subtitles and direct video publishing to Instagram Reels and YouTube Shorts, turbo mode, webhooks, and automated content autopilot.",
   "author": {
     "name": "Citedy",

--- a/SKILL.md
+++ b/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected. Article/post auto-publish supports: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts (matches `PUBLISH_PLATFORMS`). Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Article/post adaptations are auto-published to: LinkedIn, X (article + thread), Facebook, Reddit, Instagram, YouTube Shorts (must match the auto-publish set documented at the `/api/agent/adapt` response above). Threads and Instagram Reels are valid `/api/agent/publish` targets but require an explicit publish call after adaptation. Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -9,7 +9,7 @@ description: >
   Threads, Instagram, Instagram Reels, YouTube Shorts, and Shopify, generate lead magnets (checklists, swipe files,
   frameworks), ingest any URL (YouTube videos, web articles, PDFs, audio files) into structured
   content, ultra-cheap turbo articles from 2 credits, generate short-form
-  AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
+  AI UGC viral videos with subtitles and direct publishing to Instagram Reels, YouTube Shorts, and TikTok, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
 version: "3.6.2"
 author: Citedy
@@ -66,7 +66,7 @@ Use this skill when the user asks to:
 - Set up automated content sessions (cron-based article generation)
 - Generate lead magnets (checklists, swipe files, frameworks) for lead capture
 - Ingest any URL (YouTube video, web article) into structured content with summary and metadata
-- Generate short-form AI UGC viral videos with subtitles (script, avatar, video, merge) and publish directly to Instagram Reels and YouTube Shorts
+- Generate short-form AI UGC viral videos with subtitles (script, avatar, video, merge) and publish directly to Instagram Reels, YouTube Shorts, and TikTok
 - Register webhook endpoints to receive real-time event notifications (article published, ingestion complete, etc.)
 - List or delete webhook endpoints, view webhook delivery history
 - List published articles or check agent balance, status, and rate limits

--- a/SKILL.md
+++ b/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.6.1"
+version: "3.6.2"
 author: Citedy
 tags:
   - seo
@@ -398,7 +398,7 @@ When `source_urls` is provided, the response includes `extraction_results` showi
 
 The response includes `article_url` — always use this URL when sharing the article link. Do NOT construct URLs manually.
 
-When `auto_publish` is `true` (default), articles are auto-published and the URL works immediately. When `false`, the article is saved as a draft — the response returns `status: "generated"` instead of `"published"`. Use `POST /api/agent/articles/{id}/publish` to publish it later.
+When `auto_publish` is `true` (default), the response returns `status: "publishing"` once the article is saved and the publish pipeline is triggered. Treat `"publishing"` as the terminal article-generation state, not as confirmation that the social publish step has finished — that completes asynchronously. When `auto_publish` is `false`, the article is saved as a draft and the response returns `status: "generated"`. Use `POST /api/agent/articles/{id}/publish` to publish it later.
 
 `/api/agent/me` also returns `blog_url` — the tenant's blog root URL.
 
@@ -1384,5 +1384,5 @@ Call `GET /api/agent/me` every 4 hours as a keep-alive. This updates `last_activ
 
 ---
 
-_Citedy SEO Agent Skill v3.6.1_
+_Citedy SEO Agent Skill v3.6.2_
 _https://www.citedy.com_

--- a/SKILL.md
+++ b/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected (LinkedIn, X, Reddit, Instagram). Other platforms return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Currently supported: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, TikTok, and Shopify. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 
@@ -844,8 +844,8 @@ POST /api/agent/shorts/publish
 - `video_url` — HTTPS URL from `/shorts` or `/shorts/merge` response (must be `download.citedy.com` or Supabase storage)
 - `speech_text` — original spoken text; used to derive title, hashtags, descriptions via LLM
 - `targets` — 1-3 entries (max 3 platforms), each platform may appear at most once. `platform` is one of `youtube_shorts` | `instagram_reels` | `tiktok`. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
-- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. TikTok ignores it whenever `tiktok_privacy_level` is provided (always set `tiktok_privacy_level` explicitly when publishing to TikTok)
-- `tiktok_privacy_level` — TikTok-only and **required** when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
+- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. For TikTok, `privacy_status: "private"` works as a legacy fallback that maps to `tiktok_privacy_level: "SELF_ONLY"`, but new integrations should always set `tiktok_privacy_level` explicitly
+- `tiktok_privacy_level` — TikTok-only. Strongly recommended (effectively required) when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The only fallback is `privacy_status: "private"` → `SELF_ONLY` (legacy); everything else without an explicit `tiktok_privacy_level` is rejected with a 400. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
 - Returns `{ results: [{ platform, ok, post_id?, error? }], metadata_provider, metadata_degraded, timings: { metadata_ms, total_ms }, credits_charged }`
 - Does **not** require an article — publishes directly from video URL + speech text
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected. Currently supported: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, TikTok, and Shopify. Platforms without a connected account return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Article/post auto-publish supports: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts (matches `PUBLISH_PLATFORMS`). Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 

--- a/autogpt/actions.json
+++ b/autogpt/actions.json
@@ -523,7 +523,7 @@
       "id": "shorts_publish",
       "method": "POST",
       "path": "/api/agent/shorts/publish",
-      "description": "Publish video directly to YouTube Shorts, Instagram Reels, and/or TikTok. tiktok_privacy_level is required when targets includes TikTok.",
+      "description": "Publish video directly to YouTube Shorts, Instagram Reels, and/or TikTok. tiktok_privacy_level is strongly recommended (effectively required) when targets includes TikTok; the only fallback is privacy_status=\"private\" which maps to SELF_ONLY.",
       "cost": "free",
       "payload_example": {
         "video_url": "https://download.citedy.com/agent/shorts/.../video-sub.mp4",

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected. Article/post auto-publish supports: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts (matches `PUBLISH_PLATFORMS`). Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Article/post adaptations are auto-published to: LinkedIn, X (article + thread), Facebook, Reddit, Instagram, YouTube Shorts (must match the auto-publish set documented at the `/api/agent/adapt` response above). Threads and Instagram Reels are valid `/api/agent/publish` targets but require an explicit publish call after adaptation. Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -9,7 +9,7 @@ description: >
   Threads, Instagram, Instagram Reels, YouTube Shorts, and Shopify, generate lead magnets (checklists, swipe files,
   frameworks), ingest any URL (YouTube videos, web articles, PDFs, audio files) into structured
   content, ultra-cheap turbo articles from 2 credits, generate short-form
-  AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
+  AI UGC viral videos with subtitles and direct publishing to Instagram Reels, YouTube Shorts, and TikTok, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
 version: "3.6.2"
 author: Citedy
@@ -66,7 +66,7 @@ Use this skill when the user asks to:
 - Set up automated content sessions (cron-based article generation)
 - Generate lead magnets (checklists, swipe files, frameworks) for lead capture
 - Ingest any URL (YouTube video, web article) into structured content with summary and metadata
-- Generate short-form AI UGC viral videos with subtitles (script, avatar, video, merge) and publish directly to Instagram Reels and YouTube Shorts
+- Generate short-form AI UGC viral videos with subtitles (script, avatar, video, merge) and publish directly to Instagram Reels, YouTube Shorts, and TikTok
 - Register webhook endpoints to receive real-time event notifications (article published, ingestion complete, etc.)
 - List or delete webhook endpoints, view webhook delivery history
 - List published articles or check agent balance, status, and rate limits

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.6.1"
+version: "3.6.2"
 author: Citedy
 tags:
   - seo
@@ -398,7 +398,7 @@ When `source_urls` is provided, the response includes `extraction_results` showi
 
 The response includes `article_url` — always use this URL when sharing the article link. Do NOT construct URLs manually.
 
-When `auto_publish` is `true` (default), articles are auto-published and the URL works immediately. When `false`, the article is saved as a draft — the response returns `status: "generated"` instead of `"published"`. Use `POST /api/agent/articles/{id}/publish` to publish it later.
+When `auto_publish` is `true` (default), the response returns `status: "publishing"` once the article is saved and the publish pipeline is triggered. Treat `"publishing"` as the terminal article-generation state, not as confirmation that the social publish step has finished — that completes asynchronously. When `auto_publish` is `false`, the article is saved as a draft and the response returns `status: "generated"`. Use `POST /api/agent/articles/{id}/publish` to publish it later.
 
 `/api/agent/me` also returns `blog_url` — the tenant's blog root URL.
 
@@ -1384,5 +1384,5 @@ Call `GET /api/agent/me` every 4 hours as a keep-alive. This updates `last_activ
 
 ---
 
-_Citedy SEO Agent Skill v3.6.1_
+_Citedy SEO Agent Skill v3.6.2_
 _https://www.citedy.com_

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected (LinkedIn, X, Reddit, Instagram). Other platforms return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Currently supported: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, TikTok, and Shopify. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 
@@ -844,8 +844,8 @@ POST /api/agent/shorts/publish
 - `video_url` — HTTPS URL from `/shorts` or `/shorts/merge` response (must be `download.citedy.com` or Supabase storage)
 - `speech_text` — original spoken text; used to derive title, hashtags, descriptions via LLM
 - `targets` — 1-3 entries (max 3 platforms), each platform may appear at most once. `platform` is one of `youtube_shorts` | `instagram_reels` | `tiktok`. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
-- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. TikTok ignores it whenever `tiktok_privacy_level` is provided (always set `tiktok_privacy_level` explicitly when publishing to TikTok)
-- `tiktok_privacy_level` — TikTok-only and **required** when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
+- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. For TikTok, `privacy_status: "private"` works as a legacy fallback that maps to `tiktok_privacy_level: "SELF_ONLY"`, but new integrations should always set `tiktok_privacy_level` explicitly
+- `tiktok_privacy_level` — TikTok-only. Strongly recommended (effectively required) when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The only fallback is `privacy_status: "private"` → `SELF_ONLY` (legacy); everything else without an explicit `tiktok_privacy_level` is rejected with a 400. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
 - Returns `{ results: [{ platform, ok, post_id?, error? }], metadata_provider, metadata_degraded, timings: { metadata_ms, total_ms }, credits_charged }`
 - Does **not** require an article — publishes directly from video URL + speech text
 

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected. Currently supported: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, TikTok, and Shopify. Platforms without a connected account return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Article/post auto-publish supports: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts (matches `PUBLISH_PLATFORMS`). Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 

--- a/skills/citedy-content-ingestion/README.md
+++ b/skills/citedy-content-ingestion/README.md
@@ -79,7 +79,7 @@ Top up at [citedy.com/dashboard/billing](https://www.citedy.com/dashboard/billin
 
 ## Part of Citedy SEO Agent
 
-This is a focused skill from the [Citedy SEO Agent](https://github.com/citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
+This is a focused skill from the [Citedy SEO Agent](https://github.com/Citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
 
 ---
 

--- a/skills/citedy-content-writer/README.md
+++ b/skills/citedy-content-writer/README.md
@@ -85,7 +85,7 @@ Top up at [citedy.com/dashboard/billing](https://www.citedy.com/dashboard/billin
 
 ## Part of Citedy SEO Agent
 
-This is a focused skill from the [Citedy SEO Agent](https://github.com/citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
+This is a focused skill from the [Citedy SEO Agent](https://github.com/Citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
 
 ---
 

--- a/skills/citedy-content-writer/SKILL.md
+++ b/skills/citedy-content-writer/SKILL.md
@@ -340,7 +340,7 @@ Content-Type: application/json
 
 **Agent flow:**
 
-1. Call `POST /api/agent/autopilot` with `source_urls: ["https://competitor.com/best-crm-tools"]`, `size: "standard"`, `language: "en"` — synchronous; the response includes the full article (title, URL, word count, content)
+1. Call `POST /api/agent/autopilot` with `source_urls: ["https://competitor.com/best-crm-tools"]`, `size: "standard"`, `language: "en"` — typically returns the full article inline (terminal `status: "generated" | "publishing" | "published"`); if the response is queued (`status: "processing"`), poll `GET /api/agent/articles/{id}` or wait for the `article.generated` / `article.published` webhook
 2. Return article title, URL, and word count to user
 3. Ask: "Want social media adaptations? Which platforms?"
 
@@ -797,7 +797,7 @@ When an error occurs:
 ## Response Guidelines for the Agent
 
 - Always show the user the article title and URL after successful generation
-- Article generation is synchronous — the response includes the full article. No polling needed
+- Article generation usually returns the article inline. Check the `/api/agent/autopilot` response: if `status` is a terminal value (`"generated"`, `"publishing"`, `"published"`, or `"failed"`), the article is ready and you can present it immediately. If `status` is `"processing"` (or another non-terminal value — e.g. when the transform pipeline returns 202 admission), poll `GET /api/agent/articles/{id}` until it reaches a terminal status, or wait for the corresponding webhook (`article.generated`, `article.published`, `article.failed`)
 - Present credit costs before starting expensive operations (full/pillar articles, audio)
 - After generating an article, proactively offer social adaptations
 - After social adaptations, offer to publish or schedule

--- a/skills/citedy-content-writer/SKILL.md
+++ b/skills/citedy-content-writer/SKILL.md
@@ -797,7 +797,10 @@ When an error occurs:
 ## Response Guidelines for the Agent
 
 - Always show the user the article title and URL after successful generation
-- Article generation usually returns the article inline. Check the `/api/agent/autopilot` response: if `status` is a terminal value (`"generated"`, `"publishing"`, `"published"`, or `"failed"`), the article is ready and you can present it immediately. If `status` is `"processing"` (or another non-terminal value — e.g. when the transform pipeline returns 202 admission), poll `GET /api/agent/articles/{id}` until it reaches a terminal status, or wait for the corresponding webhook (`article.generated`, `article.published`, `article.failed`)
+- Article generation usually returns the article inline. Check the `/api/agent/autopilot` response `status`:
+  - `"generated"`, `"publishing"`, or `"published"` (success-terminal) → the article payload is in the response; present `title`, `URL`, and `word_count` to the user.
+  - `"failed"` (failure-terminal) → there is no usable article. Surface the error (`error.message` or `error.code`) to the user and follow your retry/fallback path. Do **not** treat this as a success.
+  - `"processing"` or any other non-terminal value (e.g. when the transform pipeline returns 202 admission, or when async generation is requested) → use the response `id`/`article_id` and poll `GET /api/agent/articles/{id}` until `status` reaches a terminal value, or wait for the corresponding webhook (`article.generated`, `article.published`, `article.failed`).
 - Present credit costs before starting expensive operations (full/pillar articles, audio)
 - After generating an article, proactively offer social adaptations
 - After social adaptations, offer to publish or schedule

--- a/skills/citedy-content-writer/SKILL.md
+++ b/skills/citedy-content-writer/SKILL.md
@@ -340,7 +340,7 @@ Content-Type: application/json
 
 **Agent flow:**
 
-1. Call `POST /api/agent/autopilot` with `source_urls: ["https://competitor.com/best-crm-tools"]`, `size: "standard"`, `language: "en"` — typically returns the full article inline (terminal `status: "generated" | "publishing" | "published"`); if the response is queued (`status: "processing"`), poll `GET /api/agent/articles/{id}` or wait for the `article.generated` / `article.published` webhook
+1. Call `POST /api/agent/autopilot` with `source_urls: ["https://competitor.com/best-crm-tools"]`, `size: "standard"`, `language: "en"` — typically returns the full article inline (terminal `status: "generated" | "publishing" | "published"`); if the response is queued (`status: "processing"`), poll `GET /api/agent/articles/{id}` or wait for one of the `article.generated` / `article.published` / `article.failed` webhooks. On `article.failed` (or terminal `status: "failed"`), surface the error and skip the social-adaptations step
 2. Return article title, URL, and word count to user
 3. Ask: "Want social media adaptations? Which platforms?"
 

--- a/skills/citedy-lead-magnets/README.md
+++ b/skills/citedy-lead-magnets/README.md
@@ -72,7 +72,7 @@ Top up at [citedy.com/dashboard/billing](https://www.citedy.com/dashboard/billin
 
 ## Part of Citedy SEO Agent
 
-This is a focused skill from the [Citedy SEO Agent](https://github.com/citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
+This is a focused skill from the [Citedy SEO Agent](https://github.com/Citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
 
 ---
 

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected. Article/post auto-publish supports: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts (matches `PUBLISH_PLATFORMS`). Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Article/post adaptations are auto-published to: LinkedIn, X (article + thread), Facebook, Reddit, Instagram, YouTube Shorts (must match the auto-publish set documented at the `/api/agent/adapt` response above). Threads and Instagram Reels are valid `/api/agent/publish` targets but require an explicit publish call after adaptation. Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -9,7 +9,7 @@ description: >
   Threads, Instagram, Instagram Reels, YouTube Shorts, and Shopify, generate lead magnets (checklists, swipe files,
   frameworks), ingest any URL (YouTube videos, web articles, PDFs, audio files) into structured
   content, ultra-cheap turbo articles from 2 credits, generate short-form
-  AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
+  AI UGC viral videos with subtitles and direct publishing to Instagram Reels, YouTube Shorts, and TikTok, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
 version: "3.6.2"
 author: Citedy
@@ -66,7 +66,7 @@ Use this skill when the user asks to:
 - Set up automated content sessions (cron-based article generation)
 - Generate lead magnets (checklists, swipe files, frameworks) for lead capture
 - Ingest any URL (YouTube video, web article) into structured content with summary and metadata
-- Generate short-form AI UGC viral videos with subtitles (script, avatar, video, merge) and publish directly to Instagram Reels and YouTube Shorts
+- Generate short-form AI UGC viral videos with subtitles (script, avatar, video, merge) and publish directly to Instagram Reels, YouTube Shorts, and TikTok
 - Register webhook endpoints to receive real-time event notifications (article published, ingestion complete, etc.)
 - List or delete webhook endpoints, view webhook delivery history
 - List published articles or check agent balance, status, and rate limits

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -11,7 +11,7 @@ description: >
   content, ultra-cheap turbo articles from 2 credits, generate short-form
   AI UGC viral videos with subtitles and direct publishing to Instagram Reels and YouTube Shorts, Google Search Console performance reports,
   and run fully automated content autopilot. Powered by Citedy.
-version: "3.6.1"
+version: "3.6.2"
 author: Citedy
 tags:
   - seo
@@ -398,7 +398,7 @@ When `source_urls` is provided, the response includes `extraction_results` showi
 
 The response includes `article_url` — always use this URL when sharing the article link. Do NOT construct URLs manually.
 
-When `auto_publish` is `true` (default), articles are auto-published and the URL works immediately. When `false`, the article is saved as a draft — the response returns `status: "generated"` instead of `"published"`. Use `POST /api/agent/articles/{id}/publish` to publish it later.
+When `auto_publish` is `true` (default), the response returns `status: "publishing"` once the article is saved and the publish pipeline is triggered. Treat `"publishing"` as the terminal article-generation state, not as confirmation that the social publish step has finished — that completes asynchronously. When `auto_publish` is `false`, the article is saved as a draft and the response returns `status: "generated"`. Use `POST /api/agent/articles/{id}/publish` to publish it later.
 
 `/api/agent/me` also returns `blog_url` — the tenant's blog root URL.
 
@@ -1384,5 +1384,5 @@ Call `GET /api/agent/me` every 4 hours as a keep-alive. This updates `last_activ
 
 ---
 
-_Citedy SEO Agent Skill v3.6.1_
+_Citedy SEO Agent Skill v3.6.2_
 _https://www.citedy.com_

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected (LinkedIn, X, Reddit, Instagram). Other platforms return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Currently supported: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, TikTok, and Shopify. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 
@@ -844,8 +844,8 @@ POST /api/agent/shorts/publish
 - `video_url` — HTTPS URL from `/shorts` or `/shorts/merge` response (must be `download.citedy.com` or Supabase storage)
 - `speech_text` — original spoken text; used to derive title, hashtags, descriptions via LLM
 - `targets` — 1-3 entries (max 3 platforms), each platform may appear at most once. `platform` is one of `youtube_shorts` | `instagram_reels` | `tiktok`. Get `account_id` from `GET /api/agent/me` → `connected_platforms`
-- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. TikTok ignores it whenever `tiktok_privacy_level` is provided (always set `tiktok_privacy_level` explicitly when publishing to TikTok)
-- `tiktok_privacy_level` — TikTok-only and **required** when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
+- `privacy_status` — `public` (default), `unlisted`, `private`. YouTube respects all three. Instagram Reels ignores it. For TikTok, `privacy_status: "private"` works as a legacy fallback that maps to `tiktok_privacy_level: "SELF_ONLY"`, but new integrations should always set `tiktok_privacy_level` explicitly
+- `tiktok_privacy_level` — TikTok-only. Strongly recommended (effectively required) when `targets` includes TikTok. One of `PUBLIC_TO_EVERYONE` | `FOLLOWER_OF_CREATOR` | `MUTUAL_FOLLOW_FRIENDS` | `SELF_ONLY`. The only fallback is `privacy_status: "private"` → `SELF_ONLY` (legacy); everything else without an explicit `tiktok_privacy_level` is rejected with a 400. The end user must pick the value from the latest `creator_info.privacy_level_options` per TikTok policy — surface a chooser in your client (see Citedy's `PublishDestinationPopover` for reference UX)
 - Returns `{ results: [{ platform, ok, post_id?, error? }], metadata_provider, metadata_degraded, timings: { metadata_ms, total_ms }, credits_charged }`
 - Does **not** require an article — publishes directly from video URL + speech text
 

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -268,7 +268,7 @@ Reply to user:
 - The agent cannot perform off-page SEO tasks such as backlink building, link outreach, or Google Business Profile management.
 - Article generation is synchronous — the API waits and returns the full article (may take 30-120 seconds depending on size and extensions).
 - Only one active autopilot session is allowed per tenant at a time.
-- Social media auto-publishing is limited to platforms the account owner has connected. Currently supported: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts, TikTok, and Shopify. Platforms without a connected account return adaptation text only.
+- Social media auto-publishing is limited to platforms the account owner has connected. Article/post auto-publish supports: LinkedIn, X (article + thread), Facebook, Reddit, Threads, Instagram, Instagram Reels, YouTube Shorts (matches `PUBLISH_PLATFORMS`). Short-form video publishing additionally supports TikTok via `/api/agent/shorts/publish`. Platforms without a connected account return adaptation text only.
 - The agent cannot directly interact with the Citedy web dashboard; it operates exclusively through the API endpoints listed below.
 - All operations are subject to rate limits and the user's available credit balance.
 

--- a/skills/citedy-trend-scout/README.md
+++ b/skills/citedy-trend-scout/README.md
@@ -75,7 +75,7 @@ Top up at [citedy.com/dashboard/billing](https://www.citedy.com/dashboard/billin
 
 ## Part of Citedy SEO Agent
 
-This is a focused skill from the [Citedy SEO Agent](https://github.com/citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
+This is a focused skill from the [Citedy SEO Agent](https://github.com/Citedy/citedy-seo-agent) full suite. Install the full suite for articles, social media, video shorts, trend scouting, lead magnets, content ingestion, and more.
 
 ---
 


### PR DESCRIPTION
## Summary

Fix two regressions Codex flagged on the saas-blog [#600 mirror PR](https://github.com/nttylock/saas-blog/pull/600) (commit `d90e9a53f`). Both originated in [#8](https://github.com/Citedy/citedy-seo-agent/pull/8) when correcting the previous sync/async contradiction.

## Findings

### P1 — `skills/citedy-content-writer/SKILL.md`: restore async polling guidance

The 3.6.1 cleanup over-corrected: it told agents that article generation is always synchronous and removed the polling/webhook fallback. But `/api/agent/autopilot` can still return a queued response (transform pipeline 202 admission, or when async is requested). Agents following the simplified guidance would stop after the first call and never fetch the finished article.

Restored the dual-path text:
- Terminal status (`"generated"`, `"publishing"`, `"published"`, `"failed"`) → present immediately.
- `"processing"` (or other non-terminal) → poll `GET /api/agent/articles/{id}` or wait for `article.generated` / `article.published` / `article.failed` webhooks.

Updated the Example 1 flow at line ~343 to mention the queued fallback.

### P2 — `SKILL.md` (and 2 copies): correct auto_publish status

The 3.6.1 cleanup rewrote the `auto_publish=true` paragraph to claim "articles are auto-published and the URL works immediately" with status `"published"`. The actual API contract returns status `"publishing"` once the publish pipeline is triggered.

Verified in `saas-blog/app/api/agent/autopilot/route.ts:1544-1545`:
```ts
let blogStatus: "draft" | "publishing" | "failed" = autoPublish
  ? "publishing"
  : ...
```

Restored the original wording: `"publishing"` is the terminal article-generation state, social publish completes asynchronously.

## Version bump

`3.6.1 → 3.6.2` in 7 places: `.claude-plugin/plugin.json` + 3 SKILL.md frontmatters + 3 SKILL.md footers.

## Files changed (5)

| File | Change |
|---|---|
| `.claude-plugin/plugin.json` | version bump |
| `SKILL.md` | auto_publish paragraph + frontmatter + footer |
| `openclaw/SKILL.md` | auto_publish paragraph + frontmatter + footer |
| `skills/citedy-seo-agent/SKILL.md` | auto_publish paragraph + frontmatter + footer |
| `skills/citedy-content-writer/SKILL.md` | restored async polling guidance + Example 1 |

## After merge

1. Update saas-blog `clawhub-skill/SKILL.md` to 3.6.2 (same surgical edits)
2. `clawhub publish ./clawhub-skill --slug citedy-seo-agent --version 3.6.2`
3. Refresh saas-blog#600 mirror PR with rsync from canonical (or close it and open a new one for 3.6.2)
