### PR TITLE
fix(skills): version sync + auto-publish drift (Sentry + CodeRabbit on saas-blog#604)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Citedy SEO Agent is designed for developers, marketers, and AI enthusiasts w
 
 | Feature                     | Description                                                                                                                                   |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Auto-Publishing**         | Automatically publish to **X, LinkedIn, Shopify, Facebook, and YouTube** — no manual posting, no extra cost. This is free.                    |
+| **Auto-Publishing**         | Article/post adaptations are auto-published to **LinkedIn, X (article + thread), Facebook, Reddit, Instagram, and YouTube Shorts** — 7 platforms total. Threads and Instagram Reels require an explicit `/api/agent/publish` call after adaptation. TikTok is supported via `/api/agent/shorts/publish` for short-form video. Publishing is free across all platforms.                    |
 | **Trend Scouting**          | Discover what's trending on X/Twitter and Reddit to create timely and relevant content.                                                       |
 | **Competitor Analysis**     | Deep-analyze competitor domains to identify content gaps and opportunities.                                                                   |
 | **Deep SEO Scan**           | Run fast/deep/ultra/ultra+ scans with AI-powered search analysis and actionable recommendations.                                              |

--- a/autogpt/actions.json
+++ b/autogpt/actions.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "3.6.2",
   "base_url": "https://www.citedy.com",
   "auth": {
     "type": "bearer",
@@ -284,7 +284,11 @@
       "method": "GET",
       "path": "/api/agent/gaps",
       "description": "Get existing content gaps. Optional ?favorite_id=<uuid> scopes to a product/identity (owner-checked, hybrid filter); ?limit=1-100 (default 100).",
-      "cost": "free"
+      "cost": "free",
+      "query_params": {
+        "favorite_id": "uuid (optional) — scope to product/identity; owner-checked against ai_favorites; hybrid filter also includes legacy NULL gaps matching favorite.domain",
+        "limit": "integer (optional, 1-100, default 100) — max items returned"
+      }
     },
     {
       "id": "gaps_generate",

--- a/autogpt/agents/manifest.json
+++ b/autogpt/agents/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.2.0",
+  "version": "3.6.2",
   "templates": [
     {
       "id": "citedy-topic-to-publish",


### PR DESCRIPTION
## Summary

Hotfix for sub-component version drift in 3.6.2 caught on the saas-blog mirror PR (nttylock/saas-blog#604) by Sentry + CodeRabbit — the canonical PR #9 Codex review missed these because Codex doesn't pattern-match version sync across companion files.

## Changes

- `autogpt/actions.json` version: `3.4.0` → `3.6.2`
- `autogpt/agents/manifest.json` version: `3.2.0` → `3.6.2`
- `autogpt/actions.json` `gaps_get` action — add `query_params` metadata for `favorite_id` and `limit` (matches `articles`/`schedule`/`gsc_report` convention)
- `README.md:17` Auto-Publishing row — sync to canonical `/api/agent/adapt` auto-publish set (7 platforms: LinkedIn, X article + thread, Facebook, Reddit, Instagram, YouTube Shorts). Distinguish Threads + IG Reels (valid `/publish` targets, not auto-published) and TikTok (shorts-only).

## Why a hotfix instead of folding into v3.6.3

These are doc/contract drift, not behavior changes. v3.6.2 was just merged 2 hours ago and is currently being mirrored to the saas-blog clawhub publishing pipeline. Hotfixing under the same v3.6.2 keeps the registry version monotonic and avoids a churn bump.

## Cascade

After merge:
1. saas-blog#604 will be re-rsynced from canonical
2. clawhub publish 3.6.2 (once #604 merges)