### PR TITLE
fix(integrations/zapier): scope Step 3 gaps list to same favorite_id

### DIFF
--- a/integrations/zapier.md
+++ b/integrations/zapier.md
@@ -127,12 +127,14 @@ Every Friday at 09:00 AM.
 
 ### Step 3 — Action: Retrieve gap results
 
-| Field  | Value                                   |
-| ------ | --------------------------------------- |
-| Method | `GET`                                   |
-| URL    | `https://www.citedy.com/api/agent/gaps` |
+| Field  | Value                                                                            |
+| ------ | -------------------------------------------------------------------------------- |
+| Method | `GET`                                                                            |
+| URL    | `https://www.citedy.com/api/agent/gaps?favorite_id=00000000-0000-0000-0000-000000000000` |
 
 No body required for GET requests. Include the `Authorization` header only.
+
+> **Important:** pass the same `favorite_id` you used in Step 2 as a query param so the list is scoped to that product/identity. Without it, the response includes _all_ gaps in the tenant, not just the ones generated above. The hybrid filter also surfaces legacy gaps (created before favorite tagging existed) that match the favorite's domain. Add `&limit=10` (1–100, default 100) if you only want the top opportunities.
 
 ### Step 4 — Filter by Zapier
 


### PR DESCRIPTION
## Summary

CodeRabbit nitpick from saas-blog mirror PR #604: in `integrations/zapier.md` the example flow generates gaps with `favorite_id` in Step 2, but Step 3 lists `GET /api/agent/gaps` **without** the filter — so the Slack notification ends up summarizing every tenant gap instead of just the product/identity-scoped ones.

## Changes

- `integrations/zapier.md` Step 3:
  - URL gains `?favorite_id=<uuid>` query param
  - Added an 'Important' callout explaining: (a) why scoping matters, (b) the hybrid filter behavior (legacy NULL gaps matching favorite.domain are still surfaced), (c) the optional `limit` param

## Why low-impact

Internal usage only — Zapier integration is not a popular distribution channel for us. Treating as documentation drift fix, no behavior change. `openai-gpt-actions.md` OpenAPI spec already documented `favorite_id` correctly; only zapier.md was out of sync.