### PR TITLE
docs: add TweetClaw context and repair AutoGPT validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,28 @@ The Citedy SEO Agent provides a simple yet powerful workflow for creating and di
 
 This entire process can be automated with cron-based sessions, allowing you to create a set-and-forget content machine that works for you 24/7.
 
+## Optional X/Twitter Source Context
+
+OpenClaw users who already use
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) can pass a reviewed
+X/Twitter source pack into Citedy before running trend scouting, article
+generation, or social adaptation. This is useful when the brief depends on
+specific tweet URLs, reply excerpts, public metrics, user lookup notes,
+follower-export summaries, media references, monitor snapshots, or webhook
+events.
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Treat TweetClaw output as source material only. Citedy remains responsible for
+topic selection, article generation, social adaptations, publishing, scheduling,
+webhooks, and analytics. Keep TweetClaw write-like actions such as posts,
+replies, DMs, follows, media uploads, monitor creation, and giveaway draws in
+the TweetClaw/OpenClaw approval flow, and do not paste API keys, cookies,
+browser profiles, or raw session material into prompts, logs, issues, or
+commits.
+
 ---
 
 ## The Citedy Advantage

--- a/SKILL.md
+++ b/SKILL.md
@@ -186,6 +186,31 @@ Check search performance, find content opportunities, write and publish:
 
 If GSC is not connected, the report returns `connected: false` with a URL to connect it.
 
+### Optional: TweetClaw X/Twitter Source Context
+
+When an OpenClaw user already has TweetClaw installed, you may use its reviewed
+read results as source material before calling Citedy workflows:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Good source packets include tweet URLs, reply excerpts, public metrics, user
+lookup notes, follower-export summaries, media references, monitor snapshots,
+or webhook event summaries. Use those packets to choose a Citedy scout query,
+`topic`, `source_urls`, or adaptation brief.
+
+Keep boundaries clear:
+
+- Citedy remains responsible for trend scouting, article generation, social
+  adaptations, publishing, scheduling, webhooks, and analytics.
+- TweetClaw remains the source of reviewed X/Twitter account evidence and any
+  TweetClaw write-like action.
+- Posts, replies, DMs, follows, media uploads, monitor creation, and giveaway
+  draws must stay inside the TweetClaw/OpenClaw approval flow.
+- Never paste API keys, cookies, browser profiles, or raw session material into
+  prompts, logs, issues, or commits.
+
 ### Choosing the Right Path
 
 | User intent                   | Best path              | Why                                     |

--- a/autogpt/agents/manifest.json
+++ b/autogpt/agents/manifest.json
@@ -5,7 +5,7 @@
       "id": "citedy-topic-to-publish",
       "file": "citedy-topic-to-publish.agent.json",
       "name": "Citedy Topic to Publish",
-      "description": "Turn any topic into a complete, SEO-optimized article with optional AI illustrations and voice-over — all in one automated step (15-48 credits). Handles research, structure, internal linking, and publishing.",
+      "description": "Turn any topic into a complete, SEO-optimized article with optional AI illustrations and voice-over - all in one automated step (15-48 credits). Handles research, structure, internal linking, and publishing.",
       "endpoint": "https://www.citedy.com/api/agent/autopilot",
       "method": "POST"
     },
@@ -13,7 +13,7 @@
       "id": "citedy-url-to-publish",
       "file": "citedy-url-to-publish.agent.json",
       "name": "Citedy URL to Publish",
-      "description": "Feed one or more source URLs — web articles, competitor pages, research — and get a fresh, SEO-optimized article ready to publish. Repurpose what already works.",
+      "description": "Feed one or more source URLs - web articles, competitor pages, research - and get a fresh, SEO-optimized article ready to publish. Repurpose what already works.",
       "endpoint": "https://www.citedy.com/api/agent/autopilot",
       "method": "POST"
     },
@@ -21,7 +21,7 @@
       "id": "citedy-turbo-article",
       "file": "citedy-turbo-article.agent.json",
       "name": "Citedy Turbo Article",
-      "description": "Generate a fully optimized SEO article from a single keyword for just 2-4 credits — the fastest, most affordable path from idea to published content. Ideal for high-volume operations.",
+      "description": "Generate a fully optimized SEO article from a single keyword for just 2-4 credits - the fastest, most affordable path from idea to published content. Ideal for high-volume operations.",
       "endpoint": "https://www.citedy.com/api/agent/autopilot",
       "method": "POST"
     },
@@ -61,7 +61,7 @@
       "id": "citedy-micro-post",
       "file": "citedy-micro-post.agent.json",
       "name": "Citedy Micro-Post",
-      "description": "Generate concise, platform-native social posts from any topic or article in seconds — optimized for engagement on X, LinkedIn, and beyond.",
+      "description": "Generate concise, platform-native social posts from any topic or article in seconds - optimized for engagement on X, LinkedIn, and beyond.",
       "endpoint": "https://www.citedy.com/api/agent/post",
       "method": "POST"
     },
@@ -69,7 +69,7 @@
       "id": "citedy-lead-magnet",
       "file": "citedy-lead-magnet.agent.json",
       "name": "Citedy Lead Magnet",
-      "description": "Produce downloadable PDF lead magnets — checklists, swipe files, or strategic frameworks — from any topic (30-100 credits). Ready to gate behind a signup form.",
+      "description": "Produce downloadable PDF lead magnets - checklists, swipe files, or strategic frameworks - from any topic (30-100 credits). Ready to gate behind a signup form.",
       "endpoint": "https://www.citedy.com/api/agent/lead-magnets",
       "method": "POST"
     },
@@ -77,8 +77,80 @@
       "id": "citedy-ingest",
       "file": "citedy-ingest.agent.json",
       "name": "Citedy Content Ingestion",
-      "description": "Feed any URL — YouTube video, web article, PDF, or audio file — and receive clean, structured content extracted and ready for repurposing (1-55 credits).",
+      "description": "Feed any URL - YouTube video, web article, PDF, or audio file - and receive clean, structured content extracted and ready for repurposing (1-55 credits).",
       "endpoint": "https://www.citedy.com/api/agent/ingest",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-product-upload",
+      "file": "citedy-product-upload.agent.json",
+      "name": "Citedy Product Knowledge",
+      "description": "Upload product knowledge for context-aware content generation.",
+      "endpoint": "https://www.citedy.com/api/agent/products",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-publish",
+      "file": "citedy-publish.agent.json",
+      "name": "Citedy Publish",
+      "description": "Publish or schedule a social adaptation.",
+      "endpoint": "https://www.citedy.com/api/agent/publish",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-scout-to-publish",
+      "file": "citedy-scout-to-publish.agent.json",
+      "name": "Citedy Scout to Publish",
+      "description": "Discover topics before autopilot generation.",
+      "endpoint": "https://www.citedy.com/api/agent/scout/x",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-session-manager",
+      "file": "citedy-session-manager.agent.json",
+      "name": "Citedy Session Manager",
+      "description": "Create a recurring automated content session.",
+      "endpoint": "https://www.citedy.com/api/agent/session",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-shorts-avatar",
+      "file": "citedy-shorts-avatar.agent.json",
+      "name": "Citedy Shorts Avatar",
+      "description": "Generate an AI avatar image for short-form video.",
+      "endpoint": "https://www.citedy.com/api/agent/shorts/avatar",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-shorts-merge",
+      "file": "citedy-shorts-merge.agent.json",
+      "name": "Citedy Shorts Merge",
+      "description": "Merge video segments with professional subtitles.",
+      "endpoint": "https://www.citedy.com/api/agent/shorts/merge",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-shorts-script",
+      "file": "citedy-shorts-script.agent.json",
+      "name": "Citedy Shorts Script",
+      "description": "Generate a speech script for short-form video.",
+      "endpoint": "https://www.citedy.com/api/agent/shorts/script",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-shorts-video",
+      "file": "citedy-shorts-video.agent.json",
+      "name": "Citedy Shorts Video",
+      "description": "Generate an AI video segment for short-form content.",
+      "endpoint": "https://www.citedy.com/api/agent/shorts",
+      "method": "POST"
+    },
+    {
+      "id": "citedy-webhook-register",
+      "file": "citedy-webhook-register.agent.json",
+      "name": "Citedy Webhook Register",
+      "description": "Register a webhook endpoint for event notifications.",
+      "endpoint": "https://www.citedy.com/api/agent/webhooks",
       "method": "POST"
     }
   ]

--- a/autogpt/validate-templates.mjs
+++ b/autogpt/validate-templates.mjs
@@ -41,6 +41,22 @@ function actionKey(method, actionPath) {
   return `${method.toUpperCase()} ${actionPath}`;
 }
 
+function actionDiscriminator(action) {
+  const payload = action?.payload_example;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+
+  for (const key of ["action", "status"]) {
+    const value = payload[key];
+    if (typeof value === "string" && value.length > 0) {
+      return `${key}=${value}`;
+    }
+  }
+
+  return null;
+}
+
 function ensureGraph(filePath, graph) {
   if (!graph || typeof graph !== "object") {
     fail(`Graph is not an object: ${filePath}`);
@@ -170,13 +186,25 @@ if (actions && Array.isArray(actions.actions)) {
     }
 
     const key = actionKey(method, actionPath);
-    const ids = seenActionKeys.get(key) || [];
-    ids.push(id || "<no-id>");
-    seenActionKeys.set(key, ids);
+    const entries = seenActionKeys.get(key) || [];
+    entries.push({
+      id: id || "<no-id>",
+      discriminator: actionDiscriminator(action),
+    });
+    seenActionKeys.set(key, entries);
   }
 
-  for (const [key, ids] of seenActionKeys.entries()) {
-    if (ids.length > 1) {
+  for (const [key, entries] of seenActionKeys.entries()) {
+    if (entries.length > 1) {
+      const discriminators = entries.map((entry) => entry.discriminator);
+      const hasDistinctVariants =
+        discriminators.every(Boolean) &&
+        new Set(discriminators).size === entries.length;
+      if (hasDistinctVariants) {
+        continue;
+      }
+
+      const ids = entries.map((entry) => entry.id);
       fail(
         `actions.json has duplicate action endpoint '${key}' for ids: ${ids.join(", ")}`,
       );

--- a/openclaw/SKILL.md
+++ b/openclaw/SKILL.md
@@ -186,6 +186,31 @@ Check search performance, find content opportunities, write and publish:
 
 If GSC is not connected, the report returns `connected: false` with a URL to connect it.
 
+### Optional: TweetClaw X/Twitter Source Context
+
+When an OpenClaw user already has TweetClaw installed, you may use its reviewed
+read results as source material before calling Citedy workflows:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Good source packets include tweet URLs, reply excerpts, public metrics, user
+lookup notes, follower-export summaries, media references, monitor snapshots,
+or webhook event summaries. Use those packets to choose a Citedy scout query,
+`topic`, `source_urls`, or adaptation brief.
+
+Keep boundaries clear:
+
+- Citedy remains responsible for trend scouting, article generation, social
+  adaptations, publishing, scheduling, webhooks, and analytics.
+- TweetClaw remains the source of reviewed X/Twitter account evidence and any
+  TweetClaw write-like action.
+- Posts, replies, DMs, follows, media uploads, monitor creation, and giveaway
+  draws must stay inside the TweetClaw/OpenClaw approval flow.
+- Never paste API keys, cookies, browser profiles, or raw session material into
+  prompts, logs, issues, or commits.
+
 ### Choosing the Right Path
 
 | User intent                   | Best path              | Why                                     |

--- a/skills/citedy-seo-agent/README.md
+++ b/skills/citedy-seo-agent/README.md
@@ -61,6 +61,26 @@ npx openskills install Citedy/citedy-seo-agent
    { "topic": "...", "size": "standard", "language": "en" }
    ```
 
+## Optional X/Twitter Source Context
+
+OpenClaw users who already use
+[TweetClaw](https://github.com/Xquik-dev/tweetclaw) can pass a reviewed
+X/Twitter source pack into Citedy before trend scouting, article generation, or
+social adaptation. Use this only as source material: tweet URLs, reply
+excerpts, public metrics, user lookup notes, follower-export summaries, media
+references, monitor snapshots, or webhook events.
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Citedy remains responsible for topic selection, writing, social adaptations,
+publishing, scheduling, webhooks, and analytics. Keep TweetClaw write-like
+actions such as posts, replies, DMs, follows, media uploads, monitor creation,
+and giveaway draws in the TweetClaw/OpenClaw approval flow, and do not paste
+API keys, cookies, browser profiles, or raw session material into prompts,
+logs, issues, or commits.
+
 ## Full Capabilities
 
 | Feature                           | Credits             |

--- a/skills/citedy-seo-agent/SKILL.md
+++ b/skills/citedy-seo-agent/SKILL.md
@@ -186,6 +186,31 @@ Check search performance, find content opportunities, write and publish:
 
 If GSC is not connected, the report returns `connected: false` with a URL to connect it.
 
+### Optional: TweetClaw X/Twitter Source Context
+
+When an OpenClaw user already has TweetClaw installed, you may use its reviewed
+read results as source material before calling Citedy workflows:
+
+```bash
+openclaw plugins install npm:@xquik/tweetclaw
+```
+
+Good source packets include tweet URLs, reply excerpts, public metrics, user
+lookup notes, follower-export summaries, media references, monitor snapshots,
+or webhook event summaries. Use those packets to choose a Citedy scout query,
+`topic`, `source_urls`, or adaptation brief.
+
+Keep boundaries clear:
+
+- Citedy remains responsible for trend scouting, article generation, social
+  adaptations, publishing, scheduling, webhooks, and analytics.
+- TweetClaw remains the source of reviewed X/Twitter account evidence and any
+  TweetClaw write-like action.
+- Posts, replies, DMs, follows, media uploads, monitor creation, and giveaway
+  draws must stay inside the TweetClaw/OpenClaw approval flow.
+- Never paste API keys, cookies, browser profiles, or raw session material into
+  prompts, logs, issues, or commits.
+
 ### Choosing the Right Path
 
 | User intent                   | Best path              | Why                                     |


### PR DESCRIPTION
## Summary

- add optional TweetClaw/OpenClaw X/Twitter source-context guidance to the main README and skill docs
- keep Citedy responsible for trend scouting, article generation, adaptation, publishing, scheduling, webhooks, and analytics
- keep TweetClaw write-like actions inside the TweetClaw/OpenClaw approval flow
- update the root, OpenClaw, and standalone skill copies together

## Independent Repository Fix

- restore the AutoGPT manifest from 10 to all 19 shipped templates
- let the validator accept same-route action variants only when each has a unique `action` or `status` discriminator
- keep ambiguous duplicate endpoint declarations rejected

## Validation

- `node autogpt/validate-templates.mjs` - 19 templates and 69 actions pass
- ambiguous duplicate regression - the validator rejects a repeated publish discriminator
- `npm pack --dry-run --json` - changed docs, manifest, and validator are packaged
- root, OpenClaw, and standalone Skill copies are byte-identical
- the new TweetClaw repository link returns HTTP 200
- full Markdown sweep found only 2 pre-existing target placeholder/API-root 404s in each copied Skill file
- `git diff --check`
- clean merge simulation against `5dcb31d`

Disclosure: I maintain TweetClaw/Xquik. Citedy remains the owner of every Citedy workflow and action.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
